### PR TITLE
SetKeyRange

### DIFF
--- a/src/gossie/readerwriter_test.go
+++ b/src/gossie/readerwriter_test.go
@@ -349,7 +349,29 @@ func TestWriterAndReader(t *testing.T) {
 		t.Error("Error running query: ", err)
 	}
 	if inthechannel != 2 {
-		t.Error("Expected 2 rows in RangeGet call, got ", len(rows))
+		t.Error("Expected 2 rows in RangeGet call, got ", inthechannel)
+	}
+
+	rowsc, errc = cp.Reader().Cf("AllTypes").SetKeyRange([]byte("row2"), nil).RangeScan()
+	inthechannel = 0
+	for row := range rowsc {
+		if row == nil {
+			t.Fatalf("Got nil from rows channel")
+		}
+		inthechannel++
+		k := string(row.Key)
+		if k == "row2" {
+			checkRow(t, buildAllTypesTestRow("row2"), row)
+		} else {
+			t.Error("Unexpected row returned in RangeGet call: ", k)
+		}
+	}
+	err = <-errc
+	if err != nil {
+		t.Error("Error running query: ", err)
+	}
+	if inthechannel != 1 {
+		t.Error("Expected 2 rows in RangeGet with SetKeyRange call, got ", inthechannel)
 	}
 
 	rows, err = cp.Reader().Cf("AllTypes").Where([]byte("colAsciiType"), EQ, []byte("hi!")).IndexedGet(&IndexedRange{Count: 1000})

--- a/src/mockgossie/mockreader.go
+++ b/src/mockgossie/mockreader.go
@@ -55,6 +55,10 @@ func (m *MockReader) SetTokenRange(startToken, endToken string) Reader {
 	panic("not implemented")
 }
 
+func (m *MockReader) SetKeyRange(startKey, endKey []byte) Reader {
+	panic("not implemented")
+}
+
 func (m *MockReader) Get(key []byte) (*Row, error) {
 	rows := m.pool.Rows(m.cf)
 


### PR DESCRIPTION
add `Reader.SetKeyRange` to mirror `Reader.SetTokenRange`. For the common case of "resume range scan starting with key 'A'" You would want to do:

```
`reader.SetKeyRange("a", nil).RangeScan()`
```

This will start by returning key "a" and continuing from there (as the Cassandra API is "inclusive" for key ranges).
