### PR TITLE
fix deadlock in RangeScan

### DIFF
--- a/src/gossie/reader.go
+++ b/src/gossie/reader.go
@@ -463,7 +463,7 @@ func (r *reader) RangeScan() (<-chan *Row, <-chan error) {
 	sp := r.buildPredicate()
 
 	data := make(chan *Row)
-	rerr := make(chan error)
+	rerr := make(chan error, 1)
 	firstRun := true
 
 	go func() {


### PR DESCRIPTION
Here is a simple (and obvious method) for using RangeScan:

```
rowsc, errc = reader.RangeScan()
for row := range rowsc {
    // ...
}
err = <-errc
if err != nil {
     t.Error("Error running query: ", err)
}
```

Previously, this would deadlock if an error occurred because gossie was
blocking on trying to write to the `errc` channel while the user of
gossie is blocked on reading from `rowsc`.

A simple fix for this is just to add a buffer to the errc channel so we
can queue up the error for the caller to read.
